### PR TITLE
Feat/zoom refactor

### DIFF
--- a/libavfilter/opencl/zoom.cl
+++ b/libavfilter/opencl/zoom.cl
@@ -93,18 +93,19 @@ __kernel void zoom(__write_only image2d_t destination,
                    unsigned int index,
                    float2 UNCLAMPED_PAN,
                    float ZOOM,
+                   float SHADOW_ZOOM,
                    float oob_plane_color,
                    __read_only  image2d_t source)
 {
     float2 dim_in  = (float2)(get_image_dim(source).x, get_image_dim(source).y);
-    float2 dim_out = (float2)(get_image_dim(destination).x, get_image_dim(destination).y);
+    float2 dim_out = (float2)(get_image_dim(destination).x / SHADOW_ZOOM, get_image_dim(destination).y / SHADOW_ZOOM);
 
     float2 PAN = clamp_pan_inbounds(UNCLAMPED_PAN, dim_out, ZOOM, dim_in);
 
     int2 dst_location = (int2)(get_global_id(0), get_global_id(1));
 
     float2 src_location = scale_coords_pxout_to_pxin(
-        (float2)(get_global_id(0), get_global_id(1)),
+        (float2)(get_global_id(0), get_global_id(1)) / SHADOW_ZOOM,
         dim_out,
         ZOOM,
         dim_in,

--- a/libavfilter/vf_zoom.c
+++ b/libavfilter/vf_zoom.c
@@ -75,6 +75,7 @@ typedef struct ZoomContext {
 
     int             desiredWidth;
     int             desiredHeight;
+    int             exact;
     double          outAspectRatio;
 
     char*           zoom_expr_str;
@@ -118,6 +119,7 @@ static const AVOption zoom_options[] = {
     { "ar",                 "set aspect ratio",                     OFFSET(outAspectRatio), AV_OPT_TYPE_DOUBLE, {.dbl=0},            0.00    ,   100   , FLAGS },
     { "width",              "set desired width",                    OFFSET(desiredWidth),   AV_OPT_TYPE_INT   , {.i64=-1},           -1      ,   65536 , FLAGS },
     { "height",             "set desired height",                   OFFSET(desiredHeight),  AV_OPT_TYPE_INT   , {.i64=-1},           -1      ,   65536 , FLAGS },
+    { "exact",              "set frame size is exact or div by 2",  OFFSET(exact),          AV_OPT_TYPE_BOOL  , {.i64=0},            0       ,   1     , FLAGS },
     { "fillcolor",          "set color for background",             OFFSET(fillcolor.rgba), AV_OPT_TYPE_COLOR,  {.str="black@0"},    CHAR_MIN, CHAR_MAX, FLAGS },
 
     { "interpolation",      "enable interpolation when scaling",    OFFSET(interpolation),  AV_OPT_TYPE_INT,    {.i64=FAST_BILINEAR}, SWS_FAST_BILINEAR,   SPLINE, FLAGS, "interpolation"},
@@ -274,17 +276,20 @@ static int config_output(AVFilterLink *outlink)
         outlink->h = s->desiredHeight;
     }
 
-    if(outlink->w % 2 != 0){
-      outlink->w -= 1;
+    if(!s->exact) {
+        if (outlink->w % 2 != 0) {
+            outlink->w -= 1;
+        }
+        if (outlink->h % 2 != 0) {
+            outlink->h -= 1;
+        }
     }
-    if(outlink->h % 2 != 0){
-      outlink->h -= 1;
+
+    if (outlink->w <= 0) {
+        outlink->w = 2;
     }
-    if(outlink->w <= 0){
-      outlink->w = 2;
-    }
-    if(outlink->h <= 0){
-      outlink->h = 2;
+    if (outlink->h <= 0) {
+        outlink->h = 2;
     }
     return 0;
 }

--- a/libavfilter/vf_zoom_opencl.c
+++ b/libavfilter/vf_zoom_opencl.c
@@ -76,6 +76,7 @@ typedef struct ZoomOpenCLContext {
 
     int             desiredWidth;
     int             desiredHeight;
+    int             exact;
     double          outAspectRatio;
 
     char*           zoom_expr_str;
@@ -119,6 +120,7 @@ static const AVOption zoom_opencl_options[] = {
     { "ar",                 "set aspect ratio",                     OFFSET(outAspectRatio), AV_OPT_TYPE_DOUBLE, {.dbl=0},            0.00    ,   100   , FLAGS },
     { "width",              "set desired width",                    OFFSET(desiredWidth),   AV_OPT_TYPE_INT   , {.i64=-1},           -1      ,   65536 , FLAGS },
     { "height",             "set desired height",                   OFFSET(desiredHeight),  AV_OPT_TYPE_INT   , {.i64=-1},           -1      ,   65536 , FLAGS },
+    { "exact",              "set frame size is exact or div by 2",  OFFSET(exact),          AV_OPT_TYPE_BOOL  , {.i64=0},            0       ,   1     , FLAGS },
     { "fillcolor",          "set color for background",             OFFSET(fillcolor.rgba), AV_OPT_TYPE_COLOR,  {.str="black@0"},  CHAR_MIN, CHAR_MAX, FLAGS },
 
     { NULL }
@@ -245,11 +247,13 @@ static int config_output(AVFilterLink *outlink)
         outlink->h = s->desiredHeight;
     }
 
-    if(outlink->w % 2 != 0){
-      outlink->w -= 1;
-    }
-    if(outlink->h % 2 != 0){
-      outlink->h -= 1;
+    if(!s->exact) {
+        if (outlink->w % 2 != 0) {
+            outlink->w -= 1;
+        }
+        if (outlink->h % 2 != 0) {
+            outlink->h -= 1;
+        }
     }
     if(outlink->w <= 0){
       outlink->w = 2;


### PR DESCRIPTION
- added support for desired `width`/`height` instead of AR to `vf_zoom` and `vf_zoom_opencl`
- added support for exact `width`/`heigh`t (disable mod 2 enforcement) to `vf_zoom` and `vf_zoom_opencl`
  - this can crash `vf_zoom_opencl` if pixel space has chroma subsampling on the axis with odd size